### PR TITLE
Argparse support

### DIFF
--- a/daterem.py
+++ b/daterem.py
@@ -81,7 +81,12 @@ def calceaster():  # Calculate easter date
 
 
 def readdat():
-    f = open(filename, 'r')
+    try:
+        f = open(filename, 'r')
+    except:
+        print("Error: cannot open file '%s'" % filename)
+        sys.exit(1)
+
     for line in f:
         line = line.strip()
 

--- a/daterem.py
+++ b/daterem.py
@@ -12,15 +12,21 @@ def usage():
 
 def options():
     global filename
+    global born_list
+    global dead_list
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument("-f", "--file", help="file to read from", default="daterem.dat")
+    parser.add_argument("-b", "--born", help="string list indicating a born year", default="born,year")
+    parser.add_argument("-d", "--dead", help="string list indicating a start year", default="dead,started")
     parser.add_argument("date", help="search for a specific date", nargs="?", default="today")
     args = parser.parse_args()
 
     filename = args.file
+    born_list = args.born.split(",")
+    dead_list = args.dead.split(",")
 
     if args.date == "today":
         oday, omonth, oyear = map(time.strftime, ["%d", "%m", "%Y"])
@@ -143,13 +149,17 @@ def readdat():
 def printline(line):
     date, text = line.split(" ", 1)
     prt = time.strftime("%a, %d.%m.%Y", time.localtime(to_epoch(date))) + ", " + text
-    match = re.match(r".*(born|dead|started|year) (\d{4})", text)
+
+    # Default is born/year for born_list and dead/started for dead_list
+    matching_list = born_list + dead_list
+    matching_strings = str.join('|', matching_list)
+    match = re.match(r".*(" + matching_strings + ") (\d{4})", text)
 
     if match:
 
-        if match.group(1) in ('born', 'year'):
+        if match.group(1) in (born_list):
             prt += ", age "
-        elif match.group(1) in ('dead', 'started'):
+        elif match.group(1) in (dead_list):
             prt += ", ago: "
 
         age = int(ryear) - int(match.group(2))

--- a/daterem.py
+++ b/daterem.py
@@ -13,7 +13,8 @@ def usage():
 def options():
     global filename
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument("-f", "--file", help="file to read from", default="daterem.dat")
     parser.add_argument("date", help="search for a specific date", nargs="?", default="today")

--- a/daterem.py
+++ b/daterem.py
@@ -3,7 +3,7 @@
 import sys
 import re
 import time
-import getopt
+import argparse
 
 
 def usage():
@@ -11,29 +11,21 @@ def usage():
 
 
 def options():
-    try:
-        opts, args = getopt.getopt(sys.argv[1:], "hf:", ["help", "file="])
-    except getopt.GetoptError as err:
-        # print help information and exit:
-        print(err)  # will print something like "option -a not recognized"
-        usage()
-        sys.exit(1)
+    global filename
 
-    for o, a in opts:
-        if o in ("-h", "--help"):
-            usage()
-            sys.exit()
-        elif o in ("-f", "--file"):
-            filename = a
-        else:
-            assert False, "unhandled option"
+    parser = argparse.ArgumentParser()
 
-    if len(sys.argv) >= 3:
-        usage()
-        sys.exit(1)
+    parser.add_argument("-f", "--file", help="file to read from", default="daterem.dat")
+    parser.add_argument("date", help="search for a specific date", nargs="?", default="today")
+    args = parser.parse_args()
 
-    if len(sys.argv) == 2:
-        optionlist = sys.argv[1].split(".")
+    filename = args.file
+
+    if args.date == "today":
+        oday, omonth, oyear = map(time.strftime, ["%d", "%m", "%Y"])
+
+    else:
+        optionlist = args.date.split(".")
 
         if len(optionlist) == 1:
             oyear = optionlist[0]
@@ -53,9 +45,6 @@ def options():
 
         if len(omonth) == 1:
             omonth = '0' + omonth
-
-    else:
-        oday, omonth, oyear = map(time.strftime, ["%d", "%m", "%Y"])
 
     return (oday, omonth, oyear)
 
@@ -202,7 +191,6 @@ def main():
 
     alldates = []
     day = 60 * 60 * 24
-    filename = "daterem.dat"
 
     rday, rmonth, ryear = options()
     easter = calceaster()

--- a/daterem.py
+++ b/daterem.py
@@ -3,11 +3,33 @@
 import sys
 import re
 import time
+import getopt
+
+
+def usage():
+    print("\nUsage: %s [[[dd.]mm.]yyyy]\n\n" % sys.argv[0])
 
 
 def options():
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "hf:", ["help", "file="])
+    except getopt.GetoptError as err:
+        # print help information and exit:
+        print(err)  # will print something like "option -a not recognized"
+        usage()
+        sys.exit(1)
+
+    for o, a in opts:
+        if o in ("-h", "--help"):
+            usage()
+            sys.exit()
+        elif o in ("-f", "--file"):
+            filename = a
+        else:
+            assert False, "unhandled option"
+
     if len(sys.argv) >= 3:
-        print("\nUsage: %s [[[dd.]mm.]yyyy]\n\n" % sys.argv[0])
+        usage()
         sys.exit(1)
 
     if len(sys.argv) == 2:
@@ -69,7 +91,7 @@ def calceaster():  # Calculate easter date
 
 
 def readdat():
-    f = open('daterem.dat', 'r')
+    f = open(filename, 'r')
     for line in f:
         line = line.strip()
 
@@ -176,9 +198,11 @@ def main():
     global day  # One day in seconds
     global easter  # Easter date - 12:00 - in seconds since the Epoch
     global alldates  # List containing all dates
+    global filename  # The datafile (usually "daterem.dat")
 
     alldates = []
     day = 60 * 60 * 24
+    filename = "daterem.dat"
 
     rday, rmonth, ryear = options()
     easter = calceaster()


### PR DESCRIPTION
Hi Dirk,
I'm using the Python script now, too. I've added argparse support (--help etc.). In the beginning, I've tried to get the getopt module running, thus the branch name. It turned out the argparse module is more suitable.

The program behaves as before when called without parameters or when called with a date.

What do you think? Any feedback is much appreciated.

Kind regards,
Bernd

```
python ./daterem.py --help                       
usage: daterem.py [-h] [-f FILE] [-b BORN] [-d DEAD] [date]

positional arguments:
  date                  search for a specific date (default: today)

optional arguments:
  -h, --help            show this help message and exit
  -f FILE, --file FILE  file to read from (default: daterem.dat)
  -b BORN, --born BORN  string list indicating a born year (default:
                        born,year)
  -d DEAD, --dead DEAD  string list indicating a start year (default:
                        dead,started)
```