### PR TITLE
Added test routines using Perl Prove

### DIFF
--- a/t/10-basics.t
+++ b/t/10-basics.t
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 12;
+
+
+my $result;
+
+###
+
+print "# Call without parameters\n";
+
+$result = `python3 ./daterem.py`;
+
+cmp_ok( $?, '==', 0, "Exit code should be zero" );
+
+
+###
+
+print "# Call with specific date\n";
+
+$result = `python3 ./daterem.py 25.05.2010`;
+
+cmp_ok( $?, '==', 0, "Exit code should be zero" );
+like( $result, '/^Tue, /m', "It was a Tuesday" );
+like( $result, '/Dirks Logbuch/', "This entry should be found" );
+like( $result, '/Dirks Logbuch, started 2005,/', "The 'started' should be shown" );
+like( $result, '/Dirks Logbuch.*, ago: 5 years$/', "The 'ago' should be detected" );
+like( $result, '/Nerd Pride Day/', "This entry should be found" );
+like( $result, '/Nerd Pride Day, year 2006,/', "The 'year' should be shown" );
+like( $result, '/Nerd Pride Day.*, age 4 years$/m', "The 'age' should be detected" );
+
+
+###
+
+print "# Call with specific month\n";
+
+$result = `python3 ./daterem.py 04.2018`;
+
+cmp_ok( $?, '==', 0, "Exit code should be zero" );
+like( $result, '/^Sun, 01\.04\.2018, Easter Sunday/m', "Detect easter sunday" );
+like( $result, '/^Mon, 02\.04\.2018, Easter Monday/m', "Detect easter monnday" );
+
+

--- a/t/10-basics.t
+++ b/t/10-basics.t
@@ -40,6 +40,6 @@ $result = `python3 ./daterem.py 04.2018`;
 
 cmp_ok( $?, '==', 0, "Exit code should be zero" );
 like( $result, '/^Sun, 01\.04\.2018, Easter Sunday/m', "Detect easter sunday" );
-like( $result, '/^Mon, 02\.04\.2018, Easter Monday/m', "Detect easter monnday" );
+like( $result, '/^Mon, 02\.04\.2018, Easter Monday/m', "Detect easter monday" );
 
 

--- a/t/20-options.t
+++ b/t/20-options.t
@@ -1,0 +1,55 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 14;
+
+
+my $result;
+
+###
+
+print "# Call with help parameter\n";
+
+$result = `python3 ./daterem.py --help`;
+
+cmp_ok( $?, '==', 0, "Exit code should be zero" );
+like( $result, '/^usage: daterem\.py /m', "Show usage" );
+like( $result, '/^positional arguments:/m', "Show positional arguments" );
+like( $result, '/^optional arguments:/m', "Show optional arguments" );
+
+
+###
+
+print "# Call with non-existent file\n";
+
+$result = `python3 ./daterem.py --file /dev/null/non-existent/file`;
+
+cmp_ok( $?, '==', 256, "Exit code should be 256" );
+like( $result, '/^Error: cannot open file /m', "Show error message" );
+
+
+###
+
+print "# Call with specific date and a test file\n";
+
+$result = `python3 ./daterem.py --file t/testfile-1.dat 20.06.2018`;
+
+cmp_ok( $?, '==', 0, "Exit code should be zero" );
+like( $result, '/^Wed, /m', "It was a Wednesday" );
+like( $result, '/Person 1/', "Show person 1" );
+unlike( $result, '/age:/', "Don't recognize the german word geboren (born) in the default" );
+
+
+###
+
+print "# Call with specific date and a test file and the born parameter\n";
+
+$result = `python3 ./daterem.py --file t/testfile-1.dat --born geboren 20.06.2018`;
+
+cmp_ok( $?, '==', 0, "Exit code should be zero" );
+like( $result, '/^Wed, /m', "It was a Wednesday" );
+like( $result, '/Person 1/', "Show person 1" );
+like( $result, '/age 68 years/', "Recognize the german word geboren (born) now" );
+
+

--- a/t/testfile-1.dat
+++ b/t/testfile-1.dat
@@ -1,0 +1,2 @@
+# Testfile
+20.06. Person 1, geboren 1950


### PR DESCRIPTION
Hi Dirk,
I've added some test routines checking the result of different calls of daterem.py.

Kind regards,
Bernd

```bash
% prove t
t/10-basics.t ... ok     
t/20-options.t .. ok     
All tests successful.
Files=2, Tests=26,  1 wallclock secs ( 0.04 usr  0.00 sys +  0.39 cusr  0.08 csys =  0.51 CPU)
Result: PASS

% perl t/10-basics.t
1..12
# Call without parameters
ok 1 - Exit code should be zero
# Call with specific date
ok 2 - Exit code should be zero
ok 3 - It was a Tuesday
ok 4 - This entry should be found
ok 5 - The 'started' should be shown
ok 6 - The 'ago' should be detected
ok 7 - This entry should be found
ok 8 - The 'year' should be shown
ok 9 - The 'age' should be detected
# Call with specific month
ok 10 - Exit code should be zero
ok 11 - Detect easter sunday
ok 12 - Detect easter monday

% perl t/20-options.t 
1..14
# Call with help parameter
ok 1 - Exit code should be zero
ok 2 - Show usage
ok 3 - Show positional arguments
ok 4 - Show optional arguments
# Call with non-existent file
ok 5 - Exit code should be 256
ok 6 - Show error message
# Call with specific date and a test file
ok 7 - Exit code should be zero
ok 8 - It was a Wednesday
ok 9 - Show person 1
ok 10 - Don't recognize the german word geboren (born) in the default
# Call with specific date and a test file and the born parameter
ok 11 - Exit code should be zero
ok 12 - It was a Wednesday
ok 13 - Show person 1
ok 14 - Recognize the german word geboren (born) now
```