### PR TITLE
Allow empty lines in data file

### DIFF
--- a/daterem.py
+++ b/daterem.py
@@ -110,7 +110,7 @@ def readdat():
     for line in f:
         line = line.strip()
 
-        if not re.match("^#", line):
+        if line and not re.match("^#", line):
             line = re.sub(r"\s{2,}", " ", line)
             ltime, description = line.split(" ", 1)
 


### PR DESCRIPTION
Empty lines in the data file to structure it worked well with the perl version but was broken in the python version.

This simple change adds support for empty lines in the data file, which are ignored now.